### PR TITLE
chore: move certs page loading to the client

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -3,3 +3,5 @@
 /workspace.xml
 # Editor-based HTTP Client requests
 /httpRequests/
+# GitHub Copilot persisted chat sessions
+/copilot/chatSessions

--- a/app/lookup/[domain]/certs/page.tsx
+++ b/app/lookup/[domain]/certs/page.tsx
@@ -3,7 +3,7 @@
 import { ExternalLink } from 'lucide-react';
 import { Metadata } from 'next';
 import Link from 'next/link';
-import React, { FC, ReactElement } from 'react';
+import React, { FC, ReactElement, useEffect, useState } from 'react';
 
 import {
   Table,
@@ -78,15 +78,25 @@ type CertsResultsPageProps = {
 const CertsResultsPage: FC<CertsResultsPageProps> = async ({
   params: { domain },
 }): Promise<ReactElement> => {
-  const certRequests = [await lookupCerts(domain)];
+  const [certsData, setCertData] = useState<CertsData[]>([]);
+
+  useEffect(() => {
+    const certsLookup = async () => {
+      const certs = await lookupCerts(domain);
+      setCertData([certs]);
+    };
+    certsLookup();
+  }, [certsData]);
+
+  //const certRequests = [await lookupCerts(domain)];
 
   const hasParentDomain = domain.split('.').filter(Boolean).length > 2;
   if (hasParentDomain) {
     const parentDomain = domain.split('.').slice(1).join('.');
-    certRequests.push(await lookupCerts(`*.${parentDomain}`));
+    certsData.push(await lookupCerts(`*.${parentDomain}`));
   }
 
-  const certs = await Promise.all(certRequests).then((responses) =>
+  const certs = await Promise.all(certsData).then((responses) =>
     responses
       .flat()
       .sort(

--- a/app/lookup/[domain]/certs/page.tsx
+++ b/app/lookup/[domain]/certs/page.tsx
@@ -59,6 +59,7 @@ const lookupCerts = async (domain: string): Promise<CertsData> => {
       next: {
         revalidate: 60 * 60,
       },
+      mode: 'no-cors',
     }
   );
 

--- a/app/lookup/[domain]/certs/page.tsx
+++ b/app/lookup/[domain]/certs/page.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { ExternalLink } from 'lucide-react';
 import { Metadata } from 'next';
 import Link from 'next/link';
@@ -32,10 +34,10 @@ type CertsData = {
   serial_number: string;
 }[];
 
-export const runtime = 'edge';
-export const preferredRegion = 'lhr1';
-
-export const generateMetadata = ({
+// This page loads faster and is more reliable when using the edge runtime:
+// export const runtime = 'edge';
+// export const preferredRegion = 'lhr1';
+/* export const generateMetadata = ({
   params: { domain },
 }: CertsResultsPageProps): Metadata => ({
   openGraph: {
@@ -44,7 +46,7 @@ export const generateMetadata = ({
   alternates: {
     canonical: `/lookup/${domain}/certs`,
   },
-});
+}); */
 
 const lookupCerts = async (domain: string): Promise<CertsData> => {
   const response = await fetch(


### PR DESCRIPTION
From now on, the data on the Certs page will be obtained locally directly from your own client. This makes Edge runtime usage much lighter. However, this makes individual requests more time-consuming, which is why I reserve the right to change this again. Hence the commented out code.